### PR TITLE
Change player stop action

### DIFF
--- a/KPS/Core/KPSClient+Media.swift
+++ b/KPS/Core/KPSClient+Media.swift
@@ -304,8 +304,11 @@ extension KPSClient {
     
     public func mediaPlayerStop() {
     
-        mediaPlayerReset()
-        currentTrack = -1
+        // Define the stop action is reset to the first item within the play list
+        mediaPlayer.pause()
+        mediaPlayerPlay(targetTrack: 0) { _ in
+            self.mediaPlayerPause()
+        }
     }
     
     public func mediaPlayerReset(isNeedClearPlayList: Bool = false) {

--- a/KPSTests/KPSClientMediaTests.swift
+++ b/KPSTests/KPSClientMediaTests.swift
@@ -234,8 +234,8 @@ class KPSClientMediaTests: XCTestCase {
         }
         sut.mediaPlayerPlayNext { [weak self] res in
             XCTAssertTrue(res)
-            XCTAssertEqual(self?.mockMediaDelegate.mediaTrackIndex, -1, "Reach the playlist end, the current track should be -1")
-            XCTAssertNil(self?.mockMediaDelegate.currentContent, "Current content should be nil")
+            XCTAssertEqual(self?.mockMediaDelegate.mediaTrackIndex, 0, "Reach the playlist end, the current track should reset to first track")
+            XCTAssertNotNil(self?.mockMediaDelegate.currentContent, "Current content should not be nil")
             XCTAssertEqual(self?.sut.isMediaPlaying, false, "Reach the playlist end, the media player should stop playing")
         }
         
@@ -503,7 +503,7 @@ class KPSClientMediaTests: XCTestCase {
                 track += 1
             }
             NotificationCenter.default.post(name: .AVPlayerItemDidPlayToEndTime, object: nil)
-            XCTAssertEqual(self?.sut.currentTrack, -1)
+            XCTAssertEqual(self?.sut.currentTrack, 0, "The media player should auto reset to the first track if we reach the end")
             XCTAssertEqual(self?.sut.isMediaPlaying, false)
         }
     }


### PR DESCRIPTION
Make the media player stop to be set the current
track to the first one within the play list and pause the audio.