### PR TITLE
[Bug fix] Media play list should not be clear after login

### DIFF
--- a/KPS/Core/KPSClient.swift
+++ b/KPS/Core/KPSClient.swift
@@ -329,7 +329,6 @@ public final class KPSClient: NSObject {
             
             switch result {
             case let .success(response):
-                self.mediaPlayerReset(isNeedClearPlayList: true)
                 self.currentUserId = response.user.id
                 KPSClient.sessionToken = response.kpsSession
                 self.isUserLoggedIn = true


### PR DESCRIPTION
User may open the audio player, and trigger login action.
In this situation, we should keep the media play list to make the audio player
work as expected.